### PR TITLE
feat: Trigger Characters!

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "vscode-manifest": "^0.0.8"
     },
     "dependencies": {
-        "@zardoy/utils": "^0.0.6",
+        "@zardoy/utils": "^0.0.7",
         "@zardoy/vscode-utils": "^0.0.15",
         "chai": "^4.3.6",
         "delay": "^5.0.0",
@@ -122,6 +122,6 @@
         "tabWidth": 4,
         "trailingComma": "all",
         "arrowParens": "avoid",
-        "printWidth": 150
+        "printWidth": 160
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ specifiers:
   '@types/vscode': ^1.64.0
   '@vscode/test-electron': ^2.1.2
   '@zardoy/tsconfig': ^1.4.0
-  '@zardoy/utils': ^0.0.6
+  '@zardoy/utils': ^0.0.7
   '@zardoy/vscode-utils': ^0.0.15
   chai: ^4.3.6
   cross-env: ^7.0.3
@@ -45,7 +45,7 @@ specifiers:
   vscode-snippet-parser: ^0.0.5
 
 dependencies:
-  '@zardoy/utils': 0.0.6
+  '@zardoy/utils': 0.0.7
   '@zardoy/vscode-utils': 0.0.15_dglpivvyc4e67exhhadou2fmk4
   chai: 4.3.6
   delay: 5.0.0
@@ -584,8 +584,8 @@ packages:
   /@types/vscode/1.64.0:
     resolution: {integrity: sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==}
 
-  /@types/yauzl/2.9.2:
-    resolution: {integrity: sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==}
+  /@types/yauzl/2.10.0:
+    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
       '@types/node': 16.11.25
@@ -779,13 +779,13 @@ packages:
       type-fest: 2.11.2
     dev: false
 
-  /@zardoy/utils/0.0.6:
-    resolution: {integrity: sha512-t2xWo2YIKurZvDyNJFWo2YH6EgYKw6eog3D8rXDPMPk1Zu76moLCPJp13LV82+n+jTZelZ2ztI4DWEJ9xA6igw==}
+  /@zardoy/utils/0.0.7:
+    resolution: {integrity: sha512-1giNsv3+IJo+xKMwRWT6FcxL27CrwWNtvGzlPF4fIlv2NaRvIUfttUiTJnNPp6XQ/mIBdM2hp5ueMio0m0H98Q==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       lodash.compact: 3.0.1
       rambda: 6.9.0
-      type-fest: 2.11.2
+      type-fest: 2.14.0
     dev: false
 
   /@zardoy/vscode-utils/0.0.15_dglpivvyc4e67exhhadou2fmk4:
@@ -2317,7 +2317,7 @@ packages:
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
-      '@types/yauzl': 2.9.2
+      '@types/yauzl': 2.10.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4685,6 +4685,11 @@ packages:
 
   /type-fest/2.11.2:
     resolution: {integrity: sha512-reW2Y2Mpn0QNA/5fvtm5doROLwDPu2zOm5RtY7xQQS05Q7xgC8MOZ3yPNaP9m/s/sNjjFQtHo7VCNqYW2iI+Ig==}
+    engines: {node: '>=12.20'}
+    dev: false
+
+  /type-fest/2.14.0:
+    resolution: {integrity: sha512-hQnTQkFjL5ik6HF2fTAM8ycbr94UbQXK364wF930VHb0dfBJ5JBP8qwrR8TaK9zwUEk7meruo2JAUDMwvuxd/w==}
     engines: {node: '>=12.20'}
     dev: false
 

--- a/src/configurationType.ts
+++ b/src/configurationType.ts
@@ -140,6 +140,14 @@ export type Configuration = {
             name: string
             /** Should be short. Always displayed in completion widget on the same raw as label. */
             description?: string
+            when?: {
+                /**
+                 * The snippet will be visible only after typing specific character on the keyboard
+                 * Add '' (empty string) so it'll be visible after regular triggering or typing
+                 * @length 1
+                 */
+                triggerCharacters?: string[]
+            }
             /** @deprecated */
             group?: string
             // formatting?: {
@@ -155,6 +163,11 @@ export type Configuration = {
             folderIcon?: string
             sortText?: string | null
             iconType?: SnippetType
+            /**
+             * Only if `when.triggerCharacters` is used
+             * @default false
+             */
+            replaceTriggerCharacter?: boolean
             /** @deprecated */
             type?: string
         }

--- a/src/configurationTypeCache.jsonc
+++ b/src/configurationTypeCache.jsonc
@@ -1,5 +1,5 @@
 // GENERATED. DON'T EDIT MANUALLY
-// md5hash: 5590f68b0826f738ebff3c978280711f
+// md5hash: 64d35ee6fe04d5cc65aceee223f6a2da
 {
     "type": "object",
     "properties": {
@@ -302,6 +302,18 @@
                                 "description": "Should be short. Always displayed in completion widget on the same raw as label.",
                                 "type": "string"
                             },
+                            "when": {
+                                "type": "object",
+                                "properties": {
+                                    "triggerCharacters": {
+                                        "description": "The snippet will be visible only after typing specific character on the keyboard\nAdd '' (empty string) so it'll be visible after regular triggering or typing",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
                             "group": {
                                 "type": "string"
                             },
@@ -354,6 +366,11 @@
                                         "type": "number"
                                     }
                                 ]
+                            },
+                            "replaceTriggerCharacter": {
+                                "description": "Only if `when.triggerCharacters` is used",
+                                "default": false,
+                                "type": "boolean"
                             },
                             "type": {
                                 "type": "string"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,11 +7,11 @@ import { ConditionalPick } from 'type-fest'
 import { SnippetParser } from 'vscode-snippet-parser'
 import { mergeDeepRight, partition } from 'rambda'
 import { DeepRequired } from 'ts-essentials'
-import { extensionCtx, getExtensionCommandId, getExtensionSetting, getExtensionSettingId } from 'vscode-framework'
-import { omitObj, oneOf, pickObj } from '@zardoy/utils'
+import { extensionCtx, getExtensionCommandId, getExtensionSetting, getExtensionSettingId, registerActiveDevelopmentCommand } from 'vscode-framework'
+import { ensureHasProp, omitObj, oneOf, pickObj } from '@zardoy/utils'
 import escapeStringRegexp from 'escape-string-regexp'
 import { Configuration } from './configurationType'
-import { normalizeFilePathRegex } from './util'
+import { completionAddTextEdit, normalizeFilePathRegex } from './util'
 import { builtinSnippets } from './builtinSnippets'
 import { registerExperimentalSnippets } from './experimentalSnippets'
 import { CompletionInsertArg, registerCompletionInsert } from './completionInsert'
@@ -194,77 +194,106 @@ export const activate = () => {
         ]
 
         const registerSnippets = (snippetsToLoad: Configuration['customSnippets']) => {
-            const snippetsByLanguage: { [language: string]: CustomSnippet[] } = {}
+            const snippetsByLanguage: { [language: string]: { snippets: CustomSnippet[]; snippetsByTriggerChar: Record<string, CustomSnippet[]> } } = {}
             for (const snippetToLoad of snippetsToLoad) {
                 const customSnippet = mergeSnippetWithDefaults(snippetToLoad)
                 for (const language of customSnippet.when.languages) {
-                    if (!snippetsByLanguage[language]) snippetsByLanguage[language] = []
-                    snippetsByLanguage[language]!.push(mergeSnippetWithDefaults(customSnippet))
+                    if (!snippetsByLanguage[language]) snippetsByLanguage[language] = { snippets: [], snippetsByTriggerChar: {} }
+                    const snippet = mergeSnippetWithDefaults(customSnippet)
+                    for (const triggerChar of snippet.when.triggerCharacters ?? [''])
+                        if (triggerChar === '') snippetsByLanguage[language]!.snippets.push(snippet)
+                        else ensureHasProp(snippetsByLanguage[language]!.snippetsByTriggerChar, triggerChar, []).push(snippet)
                 }
             }
 
             const completionProviderDisposables = [] as vscode.Disposable[]
-            for (const [language, snippets] of Object.entries(snippetsByLanguage)) {
+            for (const [language, { snippets, snippetsByTriggerChar }] of Object.entries(snippetsByLanguage)) {
                 let triggerFromInner = false
-                const disposable = vscode.languages.registerCompletionItemProvider(normalizeLanguages(language, langsSupersets), {
-                    provideCompletionItems(document, position, _token, context) {
-                        // if (context.triggerKind !== vscode.CompletionTriggerKind.Invoke) return
-                        if (triggerFromInner) {
-                            triggerFromInner = false
-                            return []
-                        }
+                const disposable = vscode.languages.registerCompletionItemProvider(
+                    normalizeLanguages(language, langsSupersets),
+                    {
+                        provideCompletionItems(document, position, _token, { triggerCharacter }) {
+                            // if (context.triggerKind !== vscode.CompletionTriggerKind.Invoke) return
+                            if (triggerFromInner) {
+                                triggerFromInner = false
+                                return []
+                            }
 
-                        const includedSnippets = getCurrentSnippets('completion', snippets, document, position, language)
-                        return includedSnippets.map(
-                            ({ body, name, sortText, executeCommand, resolveImports, fileIcon, folderIcon, description, iconType, group, type }) => {
-                                if (group) description = group
-                                if (type) iconType = type as any
-                                //
-                                const completion = new vscode.CompletionItem(
-                                    { label: name, description },
-                                    vscode.CompletionItemKind[iconType as string | number],
-                                )
-                                completion.sortText = sortText
-                                const snippetString = new vscode.SnippetString(body)
-                                completion.insertText = snippetString
-                                const snippetPreview = new vscode.MarkdownString().appendCodeblock(new SnippetParser().text(body), document.languageId)
-                                if (fileIcon) {
-                                    completion.kind = vscode.CompletionItemKind.File
-                                    completion.detail = fileIcon
-                                }
+                            const snippetsToCheck = triggerCharacter === undefined ? snippets : snippetsByTriggerChar[triggerCharacter]!
 
-                                if (folderIcon) {
-                                    completion.kind = vscode.CompletionItemKind.Folder
-                                    completion.detail = folderIcon
-                                }
-
-                                completion.documentation = snippetPreview
-                                if (resolveImports) {
-                                    const arg: CompletionInsertArg = {
-                                        action: 'resolve-imports',
-                                        importsConfig: resolveImports,
-                                        insertPos: position,
-                                        snippetLines: body.split('\n').length,
-                                    }
-                                    completion.command = {
-                                        command: getExtensionCommandId('completionInsert'),
-                                        title: '',
-                                        arguments: [arg],
-                                    }
-                                }
-
-                                if (executeCommand)
-                                    completion.command = {
-                                        ...(typeof executeCommand === 'string' ? { command: executeCommand } : executeCommand),
-                                        title: '',
+                            const includedSnippets = getCurrentSnippets('completion', snippetsToCheck, document, position, language)
+                            return includedSnippets.map(
+                                ({
+                                    body,
+                                    name,
+                                    sortText,
+                                    executeCommand,
+                                    resolveImports,
+                                    fileIcon,
+                                    folderIcon,
+                                    description,
+                                    iconType,
+                                    group,
+                                    type,
+                                    replaceTriggerCharacter,
+                                }) => {
+                                    if (group) description = group
+                                    if (type) iconType = type as any
+                                    //
+                                    const completion = new vscode.CompletionItem(
+                                        { label: name, description },
+                                        vscode.CompletionItemKind[iconType as string | number],
+                                    )
+                                    completion.sortText = sortText
+                                    const snippetString = new vscode.SnippetString(body)
+                                    completion.insertText = snippetString
+                                    const snippetPreview = new vscode.MarkdownString().appendCodeblock(new SnippetParser().text(body), document.languageId)
+                                    if (fileIcon) {
+                                        completion.kind = vscode.CompletionItemKind.File
+                                        completion.detail = fileIcon
                                     }
 
-                                if (!body || !completion.documentation) completion.documentation = undefined
-                                return completion
-                            },
-                        )
+                                    if (folderIcon) {
+                                        completion.kind = vscode.CompletionItemKind.Folder
+                                        completion.detail = folderIcon
+                                    }
+
+                                    completion.documentation = snippetPreview
+                                    if (resolveImports) {
+                                        const arg: CompletionInsertArg = {
+                                            action: 'resolve-imports',
+                                            importsConfig: resolveImports,
+                                            insertPos: position,
+                                            snippetLines: body.split('\n').length,
+                                        }
+                                        completion.command = {
+                                            command: getExtensionCommandId('completionInsert'),
+                                            title: '',
+                                            arguments: [arg],
+                                        }
+                                    }
+
+                                    if (executeCommand)
+                                        completion.command = {
+                                            ...(typeof executeCommand === 'string' ? { command: executeCommand } : executeCommand),
+                                            title: '',
+                                        }
+
+                                    if (!body || !completion.documentation) completion.documentation = undefined
+
+                                    if (triggerCharacter && replaceTriggerCharacter)
+                                        completionAddTextEdit(completion, {
+                                            newText: '',
+                                            range: new vscode.Range(position.translate(0, -1), position),
+                                        })
+
+                                    return completion
+                                },
+                            )
+                        },
                     },
-                })
+                    ...Object.keys(snippetsByTriggerChar),
+                )
                 completionProviderDisposables.push(disposable)
             }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,7 @@
+import * as vscode from 'vscode'
 // import ts from 'typescript'
 import { normalizeRegex } from '@zardoy/vscode-utils/build/settings'
+import { ensureHasProp } from '@zardoy/utils'
 import { Configuration } from './configurationType'
 
 export const normalizeFilePathRegex = (input: string, fileType: NonNullable<Configuration['customSnippets'][number]['when']>['fileType']) => {
@@ -11,6 +13,12 @@ export const normalizeFilePathRegex = (input: string, fileType: NonNullable<Conf
         case 'tsconfig.json':
             return /(t|j)sconfig(\..+)?.json$/
     }
+}
+
+export const completionAddTextEdit = (completion: vscode.CompletionItem, textEdit: vscode.TextEdit) => {
+    const textEdits = ensureHasProp(completion, 'additionalTextEdits', [])
+    textEdits.push(textEdit)
+    return textEdits
 }
 
 // const findNodeAtPosition = (source: ts.SourceFile, character: number) => {


### PR DESCRIPTION
Presenting you absolutely new feature! Now you can target some snippets to only show after typing specific character!
It wasn't possible before to split snippets into groups, but now you can do this with new `when.triggerCharacters`: optional array.
### The Problem
Even if you have quick suggestions enabled, it doesn't mean it would show snippets after typing every character (even space).
What if we wanted to quickly specify true/false after property name or expand it as a method?

```ts
const config = {
  enableFeature
  customMethod
}
```

Here, we have two properties, we want to quickly specify `true` on first and epxand method on second.
Firstly, let's assume that we don't want complicated checks and hacks. No typing snippets.

We could add a snippet to expand it to `true`/method after a single word on the line so we could type space and... the snippet won't appear, yes, because you firstly need to trigger completions and only then you can select it, this can be super annoying

```ts
enableFeature t -> true
```

## The Solution

```json
{
            "name": "t",
            "body": ": true,",
            "when": {
                "lineHasRegex": "^\\s*\\w+ $",
                "triggerCharacters": [
                    " "
                ]
            },
            "replaceTriggerCharacter": true
        },
        // to expand it as method
                {
            "name": "fun",
            "body": "($1) {\n\t$0\n},",
            "when": {
                "lineHasRegex": "^\\s*\\w+ $",
                "triggerCharacters": [
                    " "
                ]
            },
            "replaceTriggerCharacter": true
        },
```

Also, as you can see, we also now have optional `replaceTriggerCharacter` setting, because we want to remove the trigger character (space in our case):

```ts
enableFeature t
enableFeature: true,
```

> You can use `-` or even `:` as a trigger character here

Also, as you can see now, they doesn't suffer with global snippets/completions. And, you also can't get them if you retrigger completions (you need to type space again), so this is ideal for *in-flow* snippets.

In theory it can be also used, as postfix:

```json
        {
            "name": "tChar",
            "body": "translate(0, $0)",
            "when": {
                "lineRegex": "\\wPos.$",
                "triggerCharacters": [
                    "."
                ]
            }
        }
```

// But please, don't, it'll turn into annoyance that you need write dot again. Make sure you specify additional regex.

To also register snippet as regular snippet (so it will also appear after retriggering completions), add empty string to the array of trigger characters:

`triggerCharacters: ['.', '']`

Note, that TS is currently working on providing solutions for usecases from the beginning, but examples above still would be useful for JS.